### PR TITLE
SCC-2189 Remove Avro base64 encoding

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -72,7 +72,7 @@ end
 
 def send_record_to_stream record
     begin
-        encoded_record = $out_avro_client.encode record
+        encoded_record = $out_avro_client.encode(record, base64=false)
         $logger.info "Encoded record id# #{record['id']}"
     rescue AvroError => e
         $logger.warn "Record (id# #{record['id']} failed avro validation", { :status => e.message }

--- a/spec/handler_spec.rb
+++ b/spec/handler_spec.rb
@@ -114,7 +114,7 @@ describe 'handler' do
         }
 
         it "should encode and send record when successful" do
-            @mock_avro.stubs(:encode).once.with(@test_record).returns(@test_record)
+            @mock_avro.stubs(:encode).once.with(@test_record, base64=false).returns(@test_record)
             @mock_kinesis.stubs(:<<).once.with(@test_record)
 
             send_record_to_stream(@test_record)
@@ -128,7 +128,7 @@ describe 'handler' do
         end
 
         it "should raise an error if unable to send record to kinesis" do
-            @mock_avro.stubs(:encode).once.with(@test_record).returns(@test_record)
+            @mock_avro.stubs(:encode).once.with(@test_record, base64=false).returns(@test_record)
             @mock_kinesis.stubs(:<<).once.raises(NYPLError.new('test'))
 
             expect { self.send(:send_record_to_stream, @test_record) }.to raise_error(HoldingParserError, "Failed to send encoded record to Kinesis stream")


### PR DESCRIPTION
By default the avro client base64 encodes records passed to it, and this should be the default behavior. But when passing records to Kinesis, these are base64 encoded again. To avoid this, this update sets a flag to be sure that the avro encoded records are not base64 encoded before being passed to the kinesis client.