### PR TITLE
SCC-2189 Update logger to handle nil location value

### DIFF
--- a/lib/record_manager.rb
+++ b/lib/record_manager.rb
@@ -15,7 +15,7 @@ class RecordManager
         $logger.debug "Adding location object to record"
 
         location_object = $location_client.lookup_code @record['fixedFields']['40']['value']
-        $logger.debug "Retrieved location #{location_object['label']} for code #{location_object['code']}"
+        $logger.debug "Retrieved location object", location_object 
 
         @record['location'] = location_object
     end
@@ -23,5 +23,42 @@ class RecordManager
     def _parse_holdings
         $logger.debug "Setting parsed holdings field"
         @record['holdings'] = []
+
+        # Extract all holdings strings into the holdings field
+        # _get_h_fields
+
+        # TODO Incorporate Check-In Card data to this object
+    end
+
+    def _get_h_fields
+        $logger.debug "Getting values for all h values"
+        all_h_fields = @record['varFields'].filter { |f| f['fieldTag'] == 'h' }
+        y_853_fields = @record['varFields'].filter { |f| f['marcTag'] == '853' && f['fieldTag'] == 'y' }
+
+        h_866_fields = all_h_fields.filter { |f| f['marcTag'] == '866' }
+        h_legacy_fields = all_h_fields.filter! { |f| f['content'] == nil }
+        h_863_fields = all_h_fields.filter { |f| f['marcTag'] == '863' }
+
+        @record['holdings'].push(*h_866_fields.map { |h| h['subfields'][0]['content'] })
+        @record['holdings'].push(*h_866_fields.map { |h| h['content'] })
+        @record['holdings'].push(*_parse_853_863_fields(y_853_fields, h_863_fields))
+    end
+
+    def _parse_853_863_fields y_fields, h_fields
+        y_map = y_fields.map { |y|
+            sub_map = y['subfields'].map { |s| [s['tag'], s['content']] }.to_h
+
+            [sub_map['8'], sub_map.keep_if { |k, v| k != 8 }]
+        }
+
+        h_map = h_fields.map { |h|
+            sub_map = h['subfields'].map { |s| [s['tag'], s['content']] }.to_h
+        }
+    end
+
+    def _transform_field_array_to_hash fields
+        fields.map { |f|
+            
+        }
     end
 end

--- a/spec/record_manager_spec.rb
+++ b/spec/record_manager_spec.rb
@@ -35,6 +35,18 @@ describe RecordManager do
 
             expect(@test_manager.instance_variable_get(:@record)['location']['label']).to eq('test location')
         end
+
+        it 'should return nil if no location object could be located' do
+            @test_manager.instance_variable_get(:@record)['fixedFields'] = {
+                '40' => { 'value' => 'none' }
+            }
+
+            $location_client.stubs(:lookup_code).once.returns(nil)
+
+            @test_manager.send(:_parse_location)
+
+            expect(@test_manager.instance_variable_get(:@record)['location']).to be_nil
+        end
     end
 
     describe '#_parse_holdings' do


### PR DESCRIPTION
This implements a fix to the logger to reflect an update to the location parser to return nil when a value of `none` is found for a location, or otherwise a location object cannot be found for a holding.