### PR TITLE
SCC-2189 Add basic holding parser

### DIFF
--- a/lib/record_manager.rb
+++ b/lib/record_manager.rb
@@ -25,7 +25,7 @@ class RecordManager
         @record['holdings'] = []
 
         # Extract all holdings strings into the holdings field
-        # _get_h_fields
+        _get_h_fields
 
         # TODO Incorporate Check-In Card data to this object
     end
@@ -36,29 +36,135 @@ class RecordManager
         y_853_fields = @record['varFields'].filter { |f| f['marcTag'] == '853' && f['fieldTag'] == 'y' }
 
         h_866_fields = all_h_fields.filter { |f| f['marcTag'] == '866' }
-        h_legacy_fields = all_h_fields.filter! { |f| f['content'] == nil }
+        h_legacy_fields = all_h_fields.filter { |f| f['content'] != nil }
         h_863_fields = all_h_fields.filter { |f| f['marcTag'] == '863' }
 
-        @record['holdings'].push(*h_866_fields.map { |h| h['subfields'][0]['content'] })
-        @record['holdings'].push(*h_866_fields.map { |h| h['content'] })
-        @record['holdings'].push(*_parse_853_863_fields(y_853_fields, h_863_fields))
+        @record['holdings'].push(*_create_holding_obj(h_866_fields.map { |h| h['subfields'][0]['content'] }))
+        @record['holdings'].push(*_create_holding_obj(h_legacy_fields.map { |h| h['content'] }))
+        @record['holdings'].push(*_create_holding_obj(_parse_853_863_fields(y_853_fields, h_863_fields)))
+
+        $logger.debug @record['holdings']
+    end
+
+    def _create_holding_obj holding_arr
+        holding_arr.map do |h|
+            {
+                "holding_string" => h,
+                "holding_ranges" => [],
+                "index" => false,
+                "incomplete" => false,
+                "negation" => false
+            }
+        end
     end
 
     def _parse_853_863_fields y_fields, h_fields
-        y_map = y_fields.map { |y|
-            sub_map = y['subfields'].map { |s| [s['tag'], s['content']] }.to_h
+        y_map = _transform_field_array_to_hash y_fields
+        h_map = _transform_field_array_to_hash h_fields
 
-            [sub_map['8'], sub_map.keep_if { |k, v| k != 8 }]
+        h_y_crosswalk = y_map.keys.map { |k| [k, Array.new]}.to_h
+
+        h_map.each { |k, v|
+            y_match, position = k.split('.')
+            h_y_crosswalk[y_match][position.to_i - 1] = v
         }
 
-        h_map = h_fields.map { |h|
-            sub_map = h['subfields'].map { |s| [s['tag'], s['content']] }.to_h
+        out_strings = Array.new
+        h_y_crosswalk.each { |k, v|
+            field_strings = v.map { |h|
+                field_parser = ParsedField.new(h, y_map[k])
+                field_parser.generate_string_representation
+
+                field_parser.string_rep
+            }
+            out_strings << field_strings.join('; ')
         }
+
+        out_strings
     end
 
     def _transform_field_array_to_hash fields
         fields.map { |f|
-            
-        }
+           sub_map = f['subfields'].map { |s| [s['tag'], s['content']] }.to_h 
+
+           [sub_map['8'], sub_map.keep_if { |k, v| k != "8" }]
+        }.to_h
+    end
+end
+
+
+class ParsedField
+    attr_reader :string_rep
+
+    @@enumeration_codes = "abcdef"
+    @@chronology_codes = "ijkl"
+
+    def initialize(h_field, y_field)
+        @h_field = h_field
+        @y_field = y_field
+        @string_rep = ''
+    end
+
+    def generate_string_representation
+        enumeration = _generate_enumeration
+        chronology = _generate_chronology
+        @string_rep += enumeration.length > 0 ? enumeration : ''
+        if chronology.length > 0
+            chronology = enumeration.length > 0 ? " (#{chronology})" : chronology
+            @string_rep += chronology
+        end
+    end
+
+    private
+
+    def _generate_enumeration
+        @@enumeration_codes.split('').map { |c| @h_field.include?(c) ? "#{@y_field[c]} #{@h_field[c]}" : nil }.compact.join(', ')
+    end
+
+    def _generate_chronology
+        date_component = DateComponent.new
+        components = @@chronology_codes.split('').map do |c|
+            if @h_field.include? c 
+                date_component.set_field(@y_field[c].tr('()', ''), @h_field[c])
+            end
+        end
+
+        date_component.create_str
+
+        date_component.date_str
+    end
+
+    class DateComponent
+        attr_reader :date_str
+
+        @@dash_regex = /(?:[\-]{2,}|[\-]$)/
+
+        def initialize
+            @start_year = nil
+            @end_year = nil
+            @start_month = nil
+            @end_month = nil
+            @start_day = nil
+            @end_day = nil
+
+            @date_str = ''
+        end
+
+        def set_field(component, value) 
+            value_arr = value.split('-')
+            self.instance_variable_set("@start_#{component}", value_arr[0])
+            self.instance_variable_set("@end_#{component}", value_arr[1] ? value_arr[1] : value_arr[0])
+        end
+
+        def create_str
+            start_str = "#{@start_year}-#{@start_month}-#{@start_day}".gsub(@@dash_regex, '')
+            end_str = "#{@end_year}-#{@end_month}-#{@end_day}".gsub(@@dash_regex, '')
+
+            if start_str == end_str
+                @date_str = start_str
+            else
+                @date_str = "#{start_str}/#{end_str}"
+            end
+        end
     end
 end

--- a/spec/parsedfield_spec.rb
+++ b/spec/parsedfield_spec.rb
@@ -1,0 +1,115 @@
+require_relative '../lib/record_manager'
+require_relative './handler_spec'
+
+describe ParsedField do
+    describe :initialize do
+        it 'should initialize with h and y fields' do
+            test_parser = ParsedField.new('h_field', 'y_field')
+
+            expect(test_parser.instance_variable_get(:@h_field)).to eq('h_field')
+            expect(test_parser.instance_variable_get(:@y_field)).to eq('y_field')
+            expect(test_parser.string_rep).to eq('')
+            expect(ParsedField.class_variable_get(:@@enumeration_codes)).to eq('abcdef')
+            expect(ParsedField.class_variable_get(:@@chronology_codes)).to eq('ijkl')
+        end
+    end
+
+    describe :generate_string_representation do
+        before(:each) {
+            @test_parser = ParsedField.new('h_field', 'y_field')
+        }
+
+        it 'should add enumeration to the string_rep if present' do
+            @test_parser.stubs(:_generate_enumeration).once.returns('test enum')
+            @test_parser.stubs(:_generate_chronology).once.returns('')
+
+            @test_parser.generate_string_representation
+
+            expect(@test_parser.string_rep).to eq('test enum')
+        end
+
+        it 'should add enumeration and chronology (in parens) to the string_rep if both present' do
+            @test_parser.stubs(:_generate_enumeration).once.returns('test enum')
+            @test_parser.stubs(:_generate_chronology).once.returns('test chron')
+
+            @test_parser.generate_string_representation
+
+            expect(@test_parser.string_rep).to eq('test enum (test chron)')
+        end
+
+        it 'should add chronology (sans parens) to the string_rep if no enumeration present' do
+            @test_parser.stubs(:_generate_enumeration).once.returns('')
+            @test_parser.stubs(:_generate_chronology).once.returns('test chron')
+
+            @test_parser.generate_string_representation
+
+            expect(@test_parser.string_rep).to eq('test chron')
+        end
+    end
+
+    describe :_generate_enumeration do
+        it 'should return comma delimited string of subfields in @@enumeration_codes' do
+            test_parser = ParsedField.new(
+                { 'a' => '1', 'c' => '3' },
+                { 'a' => 'v.', 'b' => 'ser.', 'c' => 'iss.' }
+            )
+
+            out_str = test_parser.send(:_generate_enumeration)
+
+            expect(out_str).to eq('v. 1, iss. 3')
+        end
+
+        it 'should return an empty string if there are no enumeration subfields in the h record' do
+            test_parser = ParsedField.new({ 'i' => '1999' }, { 'a' => 'v.' })
+
+            out_str = test_parser.send(:_generate_enumeration)
+
+            expect(out_str).to eq('')
+        end
+
+        it 'should return an empty string if there are no subfields in the h record' do
+            test_parser = ParsedField.new({ }, { 'a' => 'v.' })
+
+            out_str = test_parser.send(:_generate_enumeration)
+
+            expect(out_str).to eq('')
+        end
+    end
+
+    describe :_generate_chronology do
+        it 'should pass key/value pairs to DateComponent and get string from created object' do 
+            test_parser = ParsedField.new(
+                { 'i' => '1999', 'j' => 'Mar' },
+                { 'i' => 'year', 'j' => '(month)' }
+            )
+
+            mock_date_comp = mock()
+            ParsedField::DateComponent.stubs(:new).once.returns(mock_date_comp)
+            mock_date_comp.stubs(:set_field).once.with('year', '1999')
+            mock_date_comp.stubs(:set_field).once.with('month', 'Mar')
+            mock_date_comp.stubs(:create_str).once
+            mock_date_comp.stubs(:date_str).once.returns('1999-Mar')
+
+            out_str = test_parser.send(:_generate_chronology)
+
+            expect(out_str).to eq('1999-Mar')
+        end
+
+        it 'should pass no fields to DateComponent if no matching subfields exist and return empty string' do 
+            test_parser = ParsedField.new(
+                { 'a' => '1', 'c' => '3' },
+                { 'i' => 'year', 'j' => '(month)' }
+            )
+
+            mock_date_comp = mock()
+            ParsedField::DateComponent.stubs(:new).once.returns(mock_date_comp)
+            mock_date_comp.stubs(:set_field).never
+            mock_date_comp.stubs(:create_str).once
+            mock_date_comp.stubs(:date_str).once.returns('')
+
+            out_str = test_parser.send(:_generate_chronology)
+
+            expect(out_str).to eq('')
+        end
+    end
+end

--- a/spec/parsefield_datecomponent_spec.rb
+++ b/spec/parsefield_datecomponent_spec.rb
@@ -1,0 +1,56 @@
+require_relative '../lib/record_manager'
+require_relative './handler_spec'
+
+
+describe ParsedField::DateComponent do
+    before(:each) {
+        @test_comp = ParsedField::DateComponent.new
+    }
+
+    describe :initialize do
+        it 'should initialize instance variables to nil' do
+            expect(@test_comp.date_str).to eq('')
+            expect(@test_comp.instance_variable_get(:@start_year)).to eq(nil)
+            expect(@test_comp.instance_variable_get(:@end_day)).to eq(nil)
+        end
+    end
+
+    describe :set_field do
+        it 'should start and end to the value if no dash is present' do
+            @test_comp.set_field('year', '1999')
+
+            expect(@test_comp.instance_variable_get(:@start_year)).to eq('1999')
+            expect(@test_comp.instance_variable_get(:@end_year)).to eq('1999')
+        end
+
+        it 'should start and end to split values if ' do
+            @test_comp.set_field('year', '1999-2000')
+
+            expect(@test_comp.instance_variable_get(:@start_year)).to eq('1999')
+            expect(@test_comp.instance_variable_get(:@end_year)).to eq('2000')
+        end
+    end
+
+    describe :create_str do
+        it 'should return a single date string if start and end are identical' do
+            @test_comp.instance_variable_set(:@start_year, '1999')
+            @test_comp.instance_variable_set(:@end_year, '1999')
+
+            @test_comp.create_str
+
+            expect(@test_comp.date_str).to eq('1999')
+        end
+
+        it 'should return a date range if start and end are different' do
+            @test_comp.instance_variable_set(:@start_year, '1999')
+            @test_comp.instance_variable_set(:@end_year, '1999')
+            @test_comp.instance_variable_set(:@start_month, '02')
+            @test_comp.instance_variable_set(:@end_month, '04')
+
+            @test_comp.create_str
+
+            expect(@test_comp.date_str).to eq('1999-02/1999-04')
+
+        end
+    end
+end

--- a/spec/record_manager_spec.rb
+++ b/spec/record_manager_spec.rb
@@ -1,18 +1,66 @@
 require_relative '../lib/record_manager'
 require_relative './handler_spec'
 
+TEST_VARFIELDS = {
+    'holdings' => [],
+    'varFields' => [
+        {
+            'fieldTag' => 'h',
+            'content' => 'test holding 1'
+        },
+        {
+            'fieldTag' => 'h',
+            'marcTag' => '866',
+            'subfields' => [
+                {
+                    'content' => 'test holding 2'
+                }
+            ]
+        },
+        {
+            'fieldTag' => 'h',
+            'marcTag' => '863',
+            'subfields' => [
+                {
+                    'tag' => '8',
+                    'content' => '1.1'
+                },
+                {
+                    'tag' => 'a',
+                    'content' => 'test holding 3'
+                }
+            ]
+        },
+        {
+            'fieldTag' => 'y',
+            'marcTag' => '853',
+            'subfields' => [
+                {
+                    'tag' => '8',
+                    'content' => '1'
+                },
+                {
+                    'tag' => 'a',
+                    'content' => 'test field'
+                }
+            ]
+        }
+    ]
+}
+
+
 describe RecordManager do
     before(:each) {
         @test_manager = RecordManager.new({ 'id' => 1 })
     }
 
-    describe '#initialize' do
+    describe :initialize do
         it 'should set the initialized record as a variable' do
             expect(@test_manager.instance_variable_get(:@record)['id']).to eq(1)
         end
     end
 
-    describe '#parse_record' do
+    describe :parse_record do
         it 'should invoke parsers for locations and holdings' do
             @test_manager.stubs(:_parse_location).once
             @test_manager.stubs(:_parse_holdings).once
@@ -21,7 +69,7 @@ describe RecordManager do
         end
     end
 
-    describe '#_parse_location' do
+    describe :_parse_location do
         it 'should set a location object to the current record' do
             @test_manager.instance_variable_get(:@record)['fixedFields'] = {
                 '40' => { 'value' => 'tst' }
@@ -49,10 +97,85 @@ describe RecordManager do
         end
     end
 
-    describe '#_parse_holdings' do
-        it 'should set a holdings array' do
+    describe :_parse_holdings do
+        it 'should set a holdings array and invoke h_field parser' do
+            @test_manager.stubs(:_get_h_fields).once
+
             @test_manager.send(:_parse_holdings)
             expect(@test_manager.instance_variable_get(:@record)['holdings']).to eq([])
+        end
+    end
+
+    describe :_get_h_fields do
+        it 'should fetch all fields with the h tag and parse the legacy, 863 and 866 fields seperately' do
+            @test_manager.instance_variable_set(:@record, TEST_VARFIELDS)
+
+            @test_manager.stubs(:_create_holding_obj).once.with(['test holding 1']).returns(['test holding 1'])
+            @test_manager.stubs(:_create_holding_obj).once.with(['test holding 2']).returns(['test holding 2'])
+            @test_manager.stubs(:_create_holding_obj).once.with(['test holding 3']).returns(['test holding 3'])
+            @test_manager.stubs(:_parse_853_863_fields).once.returns(['test holding 3'])
+
+            @test_manager.send(:_get_h_fields)
+
+            expect(@test_manager.instance_variable_get(:@record)['holdings']).to eq(['test holding 2', 'test holding 1', 'test holding 3'])
+        end
+    end
+
+    describe :_create_holding_obj do
+        it 'should return an array of holdings objects for all strings passed to it' do
+            out_arr = @test_manager.send(:_create_holding_obj, ['test1', 'test2'])
+
+            expect(out_arr[0]['holding_string']).to eq('test1')
+            expect(out_arr[1]['holding_string']).to eq('test2')
+            expect(out_arr[0]['index']).to eq(false)
+            expect(out_arr[1]['index']).to eq(false)
+        end
+    end
+
+    describe :_parse_853_863_fields do
+        it 'should return string representation of 863 field' do
+            y_fields = [TEST_VARFIELDS['varFields'][3]]
+            h_fields = [TEST_VARFIELDS['varFields'][2]]
+
+            mock_parser = mock()
+            ParsedField.stubs(:new).once.with(
+                { 'a' => 'test holding 3' },
+                { 'a' => 'test field' }
+            ).returns(mock_parser)
+
+            mock_parser.stubs(:generate_string_representation).once
+            mock_parser.stubs(:string_rep).once.returns('test holding 3')
+
+            out_arr = @test_manager.send(:_parse_853_863_fields, y_fields, h_fields)
+
+            expect(out_arr).to eq(['test holding 3'])
+        end
+    end
+
+    describe :_transform_field_array_to_hash do
+        it 'should set the "8" field as the hash key' do
+            test_fields = [
+                {
+                    'subfields' => [
+                        { 'tag' => '8', 'content' => '1' },
+                        { 'tag' => 'a', 'content' => 'test'},
+                        { 'tag' => 'b', 'content' => 'other' }
+                    ]
+                },
+                {
+                    'subfields' => [
+                        { 'tag' => '8', 'content' => '2' },
+                        { 'tag' => 'a', 'content' => 'test2'},
+                        { 'tag' => 'b', 'content' => 'second' }
+                    ]
+                }
+            ]
+
+            out_hash = @test_manager.send(:_transform_field_array_to_hash, test_fields)
+
+            expect(out_hash.keys).to eq(['1', '2'])
+            expect(out_hash['1']['a']).to eq('test')
+            expect(out_hash['2']['b']).to eq('second')
         end
     end
 end


### PR DESCRIPTION
This implements a basic parser for the holdings records, mainly so that the output object can pass the Avro schema validation. It simply takes the data in the 863, 866 and legacy "h" fields and passes them into the object as strings.

This also will make it easier to find and display this data in the discovery API/SCC front-end.