### PR TITLE
Add check-in card data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ deploy:
   timeout: 60
   module_name: app
   handler_name: handle_event
-  environment:
-    variables:
+  environment_variables:
       - "LOG_LEVEL=debug"
       - "PLATFORM_API_BASE_URL=https://dev-platform.nypl.org/api/v0.1"
       - "SCHEMA_TYPE=Holding"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,19 +18,12 @@ deploy:
   timeout: 60
   module_name: app
   handler_name: handle_event
-  environment_variables:
-  - LOG_LEVEL=debug
-  - PLATFORM_API_BASE_URL=https://dev-platform.nypl.org/api/v0.1
-  - SCHEMA_TYPE=Holding
-  - KINESIS_STREAM=HoldingPostRequest-dev
-  - LOCATIONS_JSONLD_URL=https://s3.amazonaws.com/nypl-core-objects-mapping-production/by_sierra_location.json
+  environment_variables: "TEST_VAR=testing"
+  environment_variables: "LOG_LEVEL=debug"
   access_key_id: "$AWS_ACCESS_KEY_ID_DEV"
   secret_access_key: "$AWS_SECRET_ACCESS_KEY_DEV"
   on:
     branch: development
-  notifications:
-    email:
-      on_failure: always
 - provider: lambda
   function_name: SierraHoldingParser-qa
   description: A function that parses holding records from the Sierra API
@@ -41,15 +34,18 @@ deploy:
   module_name: app
   handler_name: handle_event
   environment_variables:
-  - LOG_LEVEL=debug
-  - PLATFORM_API_BASE_URL=https://qa-platform.nypl.org/api/v0.1
-  - SCHEMA_TYPE=Holding
-  - KINESIS_STREAM=HoldingPostRequest-qa
-  - LOCATIONS_JSONLD_URL=https://s3.amazonaws.com/nypl-core-objects-mapping-production/by_sierra_location.json
+    - LOG_LEVEL=debug
+    - PLATFORM_API_BASE_URL=https://qa-platform.nypl.org/api/v0.1
+    - SCHEMA_TYPE=Holding
+    - KINESIS_STREAM=HoldingPostRequest-qa
+    - LOCATIONS_JSONLD_URL=https://s3.amazonaws.com/nypl-core-objects-mapping-production/by_sierra_location.json
   access_key_id: "$AWS_ACCESS_KEY_ID_QA"
   secret_access_key: "$AWS_SECRET_ACCESS_KEY_QA"
   on:
     branch: qa
+notifications:
+  email:
+    on_failure: always
 env:
   global:
   - AWS_DEFAULT_REGION=us-east-1

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,13 @@ deploy:
   timeout: 60
   module_name: app
   handler_name: handle_event
-  environment_variables: "TEST_VAR=testing"
-  environment_variables: "LOG_LEVEL=debug"
+  environment:
+    variables:
+      - "LOG_LEVEL=debug"
+      - "PLATFORM_API_BASE_URL=https://dev-platform.nypl.org/api/v0.1"
+      - "SCHEMA_TYPE=Holding"
+      - "KINESIS_STREAM=HoldingPostRequest-dev"
+      - "LOCATIONS_JSONLD_URL=https://s3.amazonaws.com/nypl-core-objects-mapping-production/by_sierra_location.json"
   access_key_id: "$AWS_ACCESS_KEY_ID_DEV"
   secret_access_key: "$AWS_SECRET_ACCESS_KEY_DEV"
   on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 ### Added
 - Initial commit containing basic structure and location parser
 - Added supporting documentation and unit test suite
+- Added integration with check-in card data

--- a/lib/field_parser.rb
+++ b/lib/field_parser.rb
@@ -1,0 +1,75 @@
+class ParsedField
+    attr_reader :string_rep
+
+    @@enumeration_codes = "abcdef"
+    @@chronology_codes = "ijkl"
+
+    def initialize(h_field, y_field)
+        @h_field = h_field
+        @y_field = y_field
+        @string_rep = ''
+    end
+
+    def generate_string_representation
+        enumeration = _generate_enumeration
+        chronology = _generate_chronology
+        @string_rep += enumeration.length > 0 ? enumeration : ''
+        if chronology.length > 0
+            chronology = enumeration.length > 0 ? " (#{chronology})" : chronology
+            @string_rep += chronology
+        end
+    end
+
+    private
+
+    def _generate_enumeration
+        @@enumeration_codes.split('').map { |c| @h_field.include?(c) ? "#{@y_field[c]} #{@h_field[c]}" : nil }.compact.join(', ')
+    end
+
+    def _generate_chronology
+        date_component = DateComponent.new
+        components = @@chronology_codes.split('').map do |c|
+            if @h_field.include? c 
+                date_component.set_field(@y_field[c].tr('()', ''), @h_field[c])
+            end
+        end
+
+        date_component.create_str
+
+        date_component.date_str
+    end
+
+    class DateComponent
+        attr_reader :date_str
+
+        @@dash_regex = /(?:[\-]{2,}|[\-]$)/
+
+        def initialize
+            @start_year = nil
+            @end_year = nil
+            @start_month = nil
+            @end_month = nil
+            @start_day = nil
+            @end_day = nil
+
+            @date_str = ''
+        end
+
+        def set_field(component, value) 
+            value_arr = value.split('-')
+            self.instance_variable_set("@start_#{component}", value_arr[0])
+            self.instance_variable_set("@end_#{component}", value_arr[1] ? value_arr[1] : value_arr[0])
+        end
+
+        def create_str
+            start_str = "#{@start_year}-#{@start_month}-#{@start_day}".gsub(@@dash_regex, '')
+            end_str = "#{@end_year}-#{@end_month}-#{@end_day}".gsub(@@dash_regex, '')
+
+            if start_str == end_str
+                @date_str = start_str
+            else
+                @date_str = "#{start_str}/#{end_str}"
+            end
+        end
+    end
+end

--- a/lib/record_manager.rb
+++ b/lib/record_manager.rb
@@ -53,7 +53,7 @@ class RecordManager
         # Parse response into an object
         check_in_data = JSON.parse(response.body)
         $logger.debug check_in_data
-        @record['check_in_card'] = check_in_data
+        @record['checkInCards'] = check_in_data
     end
 
     def _get_h_fields

--- a/spec/parsedfield_spec.rb
+++ b/spec/parsedfield_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../lib/record_manager'
+require_relative '../lib/field_parser'
 require_relative './handler_spec'
 
 describe ParsedField do

--- a/spec/record_manager_spec.rb
+++ b/spec/record_manager_spec.rb
@@ -119,7 +119,7 @@ describe RecordManager do
 
             @test_manager.send(:_get_check_in_card)
 
-            expect(@test_manager.instance_variable_get(:@record)['check_in_card'][1]['box_id']).to eq(2)
+            expect(@test_manager.instance_variable_get(:@record)['checkInCards'][1]['box_id']).to eq(2)
         end
 
         it 'should raise a RecordError if the status code is not 200' do


### PR DESCRIPTION
This incorporates check-in card data into the holdings record. This is the last component necessary to create a full representation of each holding record and should allow SCC to fully replicate the functionality of the classic catalog regarding the display of serials data