### PR TITLE
Add missing location code error

### DIFF
--- a/lib/location_client.rb
+++ b/lib/location_client.rb
@@ -11,7 +11,7 @@ class LocationClient
         location = nil
         unless code.strip == 'none'
             code_record = @locations[code.strip]
-            unless code_record['code'] && code_record['label']
+            unless code_record && code_record['code'] && code_record['label']
               raise NYPLLocationError.new(
                 "Missing or incomplete code_record: #{code_record} for location code: #{code}"
               )

--- a/lib/location_client.rb
+++ b/lib/location_client.rb
@@ -11,10 +11,15 @@ class LocationClient
         location = nil
         unless code.strip == 'none'
             code_record = @locations[code.strip]
+            unless code_record['code'] && code_record['label']
+              raise NYPLLocationError.new(
+                "Missing or incomplete code_record: #{code_record} for location code: #{code}"
+              )
+            end
             location = { 'code' => code_record['code'], 'label' => code_record['label'] }
         end
-        
-        location 
+
+        location
     end
 
     private

--- a/spec/location_client_spec.rb
+++ b/spec/location_client_spec.rb
@@ -61,5 +61,12 @@ describe LocationClient do
 
             expect(out_object).to eq(nil)
         end
+
+        it 'should raise an error if location code is not found' do
+          expect { @test_client.lookup_code 'mak' }.to raise_error(
+            NYPLLocationError,
+            "Missing or incomplete code_record: #{nil} for location code: #{'mak'}"
+          )
+        end
     end
 end


### PR DESCRIPTION
It looks like `lookup_code` was already factored out so I just added minimal logic to raise an error in case of missing locations, and a test.