### PR TITLE
NOREF Parser Improvements for 0.0.2

### DIFF
--- a/lib/record_manager.rb
+++ b/lib/record_manager.rb
@@ -89,11 +89,11 @@ class RecordManager
     def _create_holding_obj(holding_arr)
         holding_arr.map do |h|
             {
-                holding_string: h,
-                holding_ranges: [],
-                index: false,
-                incomplete: false,
-                negation: false
+                'holding_string' => h,
+                'holding_ranges' => [],
+                'index' => false,
+                'incomplete' => false,
+                'negation' => false
             }
         end
     end

--- a/spec/parsefield_datecomponent_spec.rb
+++ b/spec/parsefield_datecomponent_spec.rb
@@ -40,6 +40,17 @@ describe ParsedField::DateComponent do
             expect(@test_comp.date_str).to eq('1999')
         end
 
+        it 'should return a single date string with the unknown value at the end if provided' do
+            @test_comp.instance_variable_set(:@start_year, '1999')
+            @test_comp.instance_variable_set(:@end_year, '1999')
+            @test_comp.instance_variable_set(:@start_unknown, '23')
+            @test_comp.instance_variable_set(:@end_unknown, '23')
+
+            @test_comp.create_str
+
+            expect(@test_comp.date_str).to eq('1999-23')
+        end
+
         it 'should return a date range if start and end are different' do
             @test_comp.instance_variable_set(:@start_year, '1999')
             @test_comp.instance_variable_set(:@end_year, '1999')

--- a/spec/record_manager_spec.rb
+++ b/spec/record_manager_spec.rb
@@ -182,10 +182,10 @@ describe RecordManager do
         it 'should return an array of holdings objects for all strings passed to it' do
             out_arr = @test_manager.send(:_create_holding_obj, ['test1', 'test2'])
 
-            expect(out_arr[0][:holding_string]).to eq('test1')
-            expect(out_arr[1][:holding_string]).to eq('test2')
-            expect(out_arr[0][:index]).to eq(false)
-            expect(out_arr[1][:index]).to eq(false)
+            expect(out_arr[0]['holding_string']).to eq('test1')
+            expect(out_arr[1]['holding_string']).to eq('test2')
+            expect(out_arr[0]['index']).to eq(false)
+            expect(out_arr[1]['index']).to eq(false)
         end
     end
 


### PR DESCRIPTION
The initial 0.0.2 commit made improvements but exposed further issues, which this commit addresses. This includes:

- Better regex matching for field names
- More accurate handling of different enumeration formatn
- Extended support for different ISO-8601 date formats
- Support for continuing fields by adding dashes

Overall this should help SCC display this data in the same manner as the classic catalog