### PR TITLE
NOREF handle missing 853 field

### DIFF
--- a/lib/field_parser.rb
+++ b/lib/field_parser.rb
@@ -96,7 +96,7 @@ class ParsedField
             return full_name if field_test.match?(field)
         end
 
-        return 'unknown' if field == '()'
+        return nil if field == '()'
 
         raise FieldParserError, "Unable to identify field #{field} for chronology"
     end
@@ -108,6 +108,7 @@ class ParsedField
     # Parses date fields into a single ISO-8601 representation
     class DateComponent
         @@dash_regex = /(?:[\-]{2}|[\-]$)/
+        @@field_order = ['year', 'month', 'day', 'unknown']
 
         def initialize
             @start_year = nil
@@ -121,6 +122,8 @@ class ParsedField
         end
 
         def set_field(component, value)
+            component = _find_next_component if component.nil?
+            puts component
             value_arr = value.split('-')
             instance_variable_set("@start_#{component}", value_arr[0])
             instance_variable_set("@end_#{component}", value_arr[1] || value_arr[0])
@@ -134,6 +137,14 @@ class ParsedField
                 start_str.length > 0 ? start_str : nil,
                 end_str.length > 0 && end_str != start_str ? end_str : nil
             ]
+        end
+
+        private
+
+        def _find_next_component
+            @@field_order.each do |f|
+                return f if instance_variable_get("@start_#{f}").nil?
+            end
         end
     end
 end

--- a/lib/record_manager.rb
+++ b/lib/record_manager.rb
@@ -5,8 +5,25 @@ require_relative './field_parser'
 # - Fetching location labels
 # - Parsing holding objects
 class RecordManager
+    @@default_y_fields = {
+        'a' => '',
+        'b' => '',
+        'c' => '',
+        'd' => '',
+        'e' => '',
+        'f' => '',
+        'i' => 'year',
+        'j' => 'month',
+        'k' => 'day',
+        'l' => ''
+    }
+
     def initialize(record)
         @record = record
+    end
+
+    def self.default_y_fields
+        @@default_y_fields
     end
 
     def parse_record
@@ -99,7 +116,7 @@ class RecordManager
     end
 
     def _parse_853_863_fields(y_fields, h_fields)
-        y_map = _transform_field_array_to_hash y_fields
+        y_map = y_fields ? _transform_field_array_to_hash(y_fields) : { '1' => @@default_y_fields }
         h_map = _transform_field_array_to_hash h_fields
 
         h_y_crosswalk = y_map.keys.map { |k| [k, []] }.to_h

--- a/lib/record_manager.rb
+++ b/lib/record_manager.rb
@@ -128,13 +128,14 @@ class RecordManager
 
         out_strings = []
         h_y_crosswalk.each do |k, v|
-            field_strings = v.map do |h|
+            out_strings << v.map do |h|
+                next if h.nil?
+
                 field_parser = ParsedField.new(h, y_map[k])
                 field_parser.generate_string_representation
 
                 field_parser.string_rep
-            end
-            out_strings << field_strings.join('; ')
+            end.compact.join('; ')
         end
 
         out_strings

--- a/spec/parsedfield_spec.rb
+++ b/spec/parsedfield_spec.rb
@@ -269,7 +269,7 @@ describe ParsedField do
             mock_date_comp = mock
             ParsedField::DateComponent.stubs(:new).once.returns(mock_date_comp)
             mock_date_comp.stubs(:set_field).once.with('year', '1999')
-            mock_date_comp.stubs(:set_field).once.with('unknown', '23-')
+            mock_date_comp.stubs(:set_field).once.with(nil, '23-')
             mock_date_comp.stubs(:set_field).never
             mock_date_comp.stubs(:create_str).once.returns('1999-23')
 
@@ -289,12 +289,12 @@ describe ParsedField do
             expect(out_field).to eq('year')
         end
 
-        it 'should return unknown if an empty set of parens is provided' do
+        it 'should return nil if an empty set of parens is provided' do
             test_parser = ParsedField.new({}, {})
 
             out_field = test_parser.send(:_standardize_date_definition_field, '()')
 
-            expect(out_field).to eq('unknown')
+            expect(out_field).to eq(nil)
         end
 
         it 'should raise an error if the date field is not recognized' do

--- a/spec/parsefield_datecomponent_spec.rb
+++ b/spec/parsefield_datecomponent_spec.rb
@@ -27,6 +27,16 @@ describe ParsedField::DateComponent do
             expect(@test_comp.instance_variable_get(:@start_year)).to eq('1999')
             expect(@test_comp.instance_variable_get(:@end_year)).to eq('2000')
         end
+
+        it 'should set the value to the next nil field if no componenent is specified' do
+            @test_comp.instance_variable_set(:@start_year, '1999')
+            @test_comp.instance_variable_set(:@end_year, '1999')
+
+            @test_comp.set_field(nil, '12')
+
+            expect(@test_comp.instance_variable_get(:@start_month)).to eq('12')
+            expect(@test_comp.instance_variable_get(:@end_month)).to eq('12')
+        end
     end
 
     describe :create_str do

--- a/spec/record_manager_spec.rb
+++ b/spec/record_manager_spec.rb
@@ -225,6 +225,25 @@ describe RecordManager do
 
             expect(out_arr).to eq(['test holding 3'])
         end
+
+        it 'should skip nil values in h field mapping and not add them to crosswalk' do
+            y_fields = [TEST_VARFIELDS['varFields'][3]]
+            h_fields = [TEST_VARFIELDS['varFields'][2]]
+            h_fields[0]['subfields'][0]['content'] = '1.2'
+
+            mock_parser = mock
+            ParsedField.stubs(:new).once.with(
+                { 'a' => 'test holding 3' },
+                { 'a' => 'test field' }
+            ).returns(mock_parser)
+
+            mock_parser.stubs(:generate_string_representation).once
+            mock_parser.stubs(:string_rep).once.returns('test holding 3')
+
+            out_arr = @test_manager.send(:_parse_853_863_fields, y_fields, h_fields)
+
+            expect(out_arr).to eq(['test holding 3'])
+        end
     end
 
     describe :_transform_field_array_to_hash do

--- a/spec/record_manager_spec.rb
+++ b/spec/record_manager_spec.rb
@@ -207,6 +207,24 @@ describe RecordManager do
 
             expect(out_arr).to eq(['test holding 3'])
         end
+
+        it 'should use default y/863 fields if no 863 object is present in holding record' do
+            y_fields = nil
+            h_fields = [TEST_VARFIELDS['varFields'][2]]
+
+            mock_parser = mock
+            ParsedField.stubs(:new).once.with(
+                { 'a' => 'test holding 3' },
+                RecordManager.default_y_fields 
+            ).returns(mock_parser)
+
+            mock_parser.stubs(:generate_string_representation).once
+            mock_parser.stubs(:string_rep).once.returns('test holding 3')
+
+            out_arr = @test_manager.send(:_parse_853_863_fields, y_fields, h_fields)
+
+            expect(out_arr).to eq(['test holding 3'])
+        end
     end
 
     describe :_transform_field_array_to_hash do


### PR DESCRIPTION
This handles a few edge cases where expected fields are not present in the `853/863` fields, or the `853` field is missing altogether.