### PR TITLE
NOREF Check for empty hash instead of nil

### DIFF
--- a/lib/field_parser.rb
+++ b/lib/field_parser.rb
@@ -123,7 +123,6 @@ class ParsedField
 
         def set_field(component, value)
             component = _find_next_component if component.nil?
-            puts component
             value_arr = value.split('-')
             instance_variable_set("@start_#{component}", value_arr[0])
             instance_variable_set("@end_#{component}", value_arr[1] || value_arr[0])

--- a/lib/record_manager.rb
+++ b/lib/record_manager.rb
@@ -116,7 +116,7 @@ class RecordManager
     end
 
     def _parse_853_863_fields(y_fields, h_fields)
-        y_map = y_fields ? _transform_field_array_to_hash(y_fields) : { '1' => @@default_y_fields }
+        y_map = y_fields.empty? ? { '1' => @@default_y_fields } : _transform_field_array_to_hash(y_fields)
         h_map = _transform_field_array_to_hash h_fields
 
         h_y_crosswalk = y_map.keys.map { |k| [k, []] }.to_h

--- a/spec/record_manager_spec.rb
+++ b/spec/record_manager_spec.rb
@@ -209,7 +209,7 @@ describe RecordManager do
         end
 
         it 'should use default y/863 fields if no 863 object is present in holding record' do
-            y_fields = nil
+            y_fields = {}
             h_fields = [TEST_VARFIELDS['varFields'][2]]
 
             mock_parser = mock


### PR DESCRIPTION
When checking for a missing `853` field the previous fix mistakenly evaluates the value for `nil` instead of checking for an empty hash. This is resolved by using `empty?` on the variable instead, which should match the return from the `filter` call.

This also removes a minor logging issue with a few values being written directly to STDOUT