### PR TITLE
NOREF Handle edge case month abbreviation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ deploy:
      IN_SCHEMA_TYPE: SierraHolding
      OUT_SCHEMA_TYPE: Holding
      KINESIS_STREAM: HoldingPostRequest-dev
-     LOCATIONS_JSONLD_URL: https://s3.amazonaws.com/nypl-core-objects-mapping-production/by_sierra_location.json
+     LOCATIONS_JSONLD_URL: https://s3.amazonaws.com/nypl-core-objects-mapping-qa/by_sierra_location.json
   access_key_id: "$AWS_ACCESS_KEY_ID_DEVELOPMENT"
   secret_access_key: "$AWS_SECRET_ACCESS_KEY_DEVELOPMENT"
   on:
@@ -61,7 +61,7 @@ deploy:
       IN_SCHEMA_TYPE: SierraHolding
       OUT_SCHEMA_TYPE: Holding
       KINESIS_STREAM: HoldingPostRequest-qa
-      LOCATIONS_JSONLD_URL: https://s3.amazonaws.com/nypl-core-objects-mapping-production/by_sierra_location.json
+      LOCATIONS_JSONLD_URL: https://s3.amazonaws.com/nypl-core-objects-mapping-qa/by_sierra_location.json
   access_key_id: "$AWS_ACCESS_KEY_ID_QA"
   secret_access_key: "$AWS_SECRET_ACCESS_KEY_QA"
   on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 0.0.4 - Unreleased
+### Fixed
+- Use QA location codes in qa/dev environments
+- Better handling of date fields (including seasons and month abbreviations)
+- Fix bug in logger when no location is attached to record
+- Improve handling of missing 853 fields in records
+
 ## 0.0.3 - 2020-10-01
 ### Fixed
 - Cleaned up parsing of holding field (863/866) objects

--- a/lib/field_parser.rb
+++ b/lib/field_parser.rb
@@ -6,7 +6,7 @@ class ParsedField
     @@chronology_codes = 'ijkl'
     @@date_field_mappings = {
         'day' => /(?<=(?:\(|^))d(?:ay|a|)(?=(?:\.|\)|$))/,
-        'month' => /(?<=(?:\(|^))m(?:onth|on|o|)(?=(?:\.|\)|$))/,
+        'month' => /(?<=(?:\(|^))m(?:onth|on|os|o|)(?=(?:\.|\)|$))/,
         'year' => /(?<=(?:\(|^))y(?:ear|ea|r|e|)(?=(?:\.|\)|$))/,
         'season' => /(?<=(?:\(|^))s(?:eason|eas|ea|e)(?=(?:\.|\)|$))/,
     }


### PR DESCRIPTION
This adds an additional form of month abbreviations ("mos") to the regex.

This also updates the change log and other environment settings to reflect recent bug fixes as this should be the final fix in this release phase.