### PR TITLE
NOREF Handle uppercase characters in subfield names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Better handling of date fields (including seasons and month abbreviations)
 - Fix bug in logger when no location is attached to record
 - Improve handling of missing 853 fields in records
+- Lowercase all field names for 853 chronologies
 
 ## 0.0.3 - 2020-10-01
 ### Fixed

--- a/lib/field_parser.rb
+++ b/lib/field_parser.rb
@@ -94,7 +94,7 @@ class ParsedField
 
     def _standardize_date_definition_field(field)
         @@date_field_mappings.each do |full_name, field_test|
-            return full_name if field_test.match?(field)
+            return full_name if field_test.match?(field.downcase)
         end
 
         return nil if field == '()'
@@ -109,7 +109,7 @@ class ParsedField
     # Parses date fields into a single ISO-8601 representation
     class DateComponent
         @@dash_regex = /(?:[\-]{2,3}|[\-]$)/
-        @@field_order = ['year', 'month', 'day', 'season','unknown']
+        @@field_order = ['year', 'month', 'day', 'season', 'unknown']
 
         def initialize
             @start_year = nil

--- a/spec/parsedfield_spec.rb
+++ b/spec/parsedfield_spec.rb
@@ -304,6 +304,14 @@ describe ParsedField do
                 test_parser.send(:_standardize_date_definition_field, '(smthg.)')
             }.to raise_error(FieldParserError, 'Unable to identify field (smthg.) for chronology')
         end
+
+        it 'should handle cases where fields contain upper case characters' do
+            test_parser = ParsedField.new({}, {})
+
+            out_field = test_parser.send(:_standardize_date_definition_field, '(Season)')
+
+            expect(out_field).to eq('season')
+        end
     end
 
     describe :_empty_field_check do


### PR DESCRIPTION
Previous assumption was that subfield values in 853 fields would always be lower case, but this cannot be trusted, so they are all coerced to lowercase to ensure proper parsing