### PR TITLE
Set defaults to deleted Holding record to pass avro validation

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -66,7 +66,7 @@ def validate_record(record)
 
     begin
         decoded = $in_avro_client.decode avro_data
-        $logger.debug 'Decoded bib', decoded
+        $logger.debug 'Decoded holding', decoded
     rescue AvroError => e
         $logger.error "Record failed Avro decoding for reason: #{e.message}"
         raise HoldingParserError, 'Incoming kinesis record failed Avro decoding'


### PR DESCRIPTION
[Previous effort](https://github.com/NYPL/SierraHoldingParser/pull/53) succeeded in passing deleted holding records through to a point, but app failed to avro-encode them because the outgoing `Holding` avro schema includes additional fields over the incoming `SierraHolding` schema. This update ensures those fields are set so that avro encoding succeeds for deleted records.