### PR TITLE
NOREF fix kinesis flush

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -52,6 +52,9 @@ def handle_event(event:, context:)
         $logger.debug "Processed and sent record # #{valid_record['id']} to kinesis"
     end
 
+    # Flush kinesis:
+    $kinesis_client.push_records
+
     $logger.info 'Processing Complete'
 end
 # rubocop:enable Lint/UnusedMethodArgument

--- a/app.rb
+++ b/app.rb
@@ -53,7 +53,7 @@ def handle_event(event:, context:)
     end
 
     # Flush kinesis:
-    $kinesis_client.push_records
+    flush_records
 
     $logger.info 'Processing Complete'
 end
@@ -88,6 +88,10 @@ rescue AvroError => e
 rescue NYPLError => e
     $logger.warn "Record (id# #{record['id']} failed to write to kinesis", { status: e.message }
     raise HoldingParserError, 'Failed to send encoded record to Kinesis stream'
+end
+
+def flush_records
+    $kinesis_client.push_records
 end
 
 class HoldingParserError < StandardError; end

--- a/spec/handler_spec.rb
+++ b/spec/handler_spec.rb
@@ -12,6 +12,7 @@ describe 'handler' do
             @avro_mock = mock
             NYPLRubyUtil::NYPLAvro.stubs(:by_name).returns(@avro_mock)
             @kinesis_mock = mock
+            @kinesis_mock.stubs(:push_records)
             NYPLRubyUtil::KinesisClient.stubs(:new).returns(@kinesis_mock)
             @locations_mock = mock
             LocationClient.stubs(:new).returns(@locations_mock)
@@ -45,6 +46,7 @@ describe 'handler' do
             stubs(:validate_record).once.with(3).returns(@records[2])
             @mock_manager.stubs(:parse_record).times(3)
             stubs(:send_record_to_stream).times(3)
+            stubs(:flush_records).once
 
             handle_event(event: { 'Records' => [1, 2, 3] }, context: {})
         end
@@ -57,6 +59,7 @@ describe 'handler' do
             @mock_manager.stubs(:parse_record).twice
             stubs(:send_record_to_stream).once.with(@records[0])
             stubs(:send_record_to_stream).once.with(@records[2])
+            stubs(:flush_records).once
 
             handle_event(event: { 'Records' => [1, 2, 3] }, context: {})
         end
@@ -70,6 +73,7 @@ describe 'handler' do
             stubs(:send_record_to_stream).once.raises(HoldingParserError.new)
             stubs(:send_record_to_stream).once.with(@records[1])
             stubs(:send_record_to_stream).once.with(@records[2])
+            stubs(:flush_records).once
 
             handle_event(event: { 'Records' => [1, 2, 3] }, context: {})
         end


### PR DESCRIPTION
Fix bug with latest nypl-ruby-util kinesis client, which fails to push kinesis events when batch_size is 1. When batch-size is > 1, client delays flushing event buffer until a full batch-size batch has been collected (which could be hours later..) This update flushes the kinesis event buffer after each lambda invocation.